### PR TITLE
chore: Remove legacy consume_all feature

### DIFF
--- a/beanstalkjobs/config.go
+++ b/beanstalkjobs/config.go
@@ -8,7 +8,6 @@ const (
 	tubePriority   string = "tube_priority"
 	tube           string = "tube"
 	reserveTimeout string = "reserve_timeout"
-	consumeAll     string = "consume_all"
 )
 
 type config struct {

--- a/schema.json
+++ b/schema.json
@@ -28,9 +28,6 @@
             "prefetch": {
               "$ref": "https://raw.githubusercontent.com/roadrunner-server/jobs/refs/heads/master/schema.json#/definitions/PipelineProperties/prefetch"
             },
-            "consume_all": {
-              "$ref": "https://raw.githubusercontent.com/roadrunner-server/jobs/refs/heads/master/schema.json#/definitions/PipelineProperties/consume_all"
-            },
             "tube_priority": {
               "description": "Beanstalk internal tube priority",
               "type": "integer",

--- a/tests/configs/.rr-beanstalk-raw.yaml
+++ b/tests/configs/.rr-beanstalk-raw.yaml
@@ -32,7 +32,6 @@ jobs:
       config:
         priority: 11
         tube_priority: 1
-        consume_all: true
         tube: default-raw
         reserve_timeout: 10s
 


### PR DESCRIPTION
# Reason for This PR

The property `consume_all` was removed and no longer serves any purpose.

This PR must be merged before https://github.com/roadrunner-server/jobs/pull/135.

## Description of Changes

Removed `consume_all`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
