### PR TITLE
fix: check out the repo before uploading coverage

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -148,16 +148,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: [beanstalk_test, beanstalk_durability]
     steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v8
         with:
           pattern: coverage-*
+          path: coverage
           merge-multiple: true
 
       - name: Merge coverage files
         run: |
           echo "mode: atomic" > summary.txt
-          cat *.out | grep -v "^mode:" | awk '{ sub(/github\.com\/roadrunner-server\/beanstalk\/v[56]\//, ""); print }' >> summary.txt
+          cat coverage/*.out | grep -v "^mode:" | awk '{ sub(/github\.com\/roadrunner-server\/beanstalk\/v[56]\//, ""); print }' >> summary.txt
+          # a profile that maps to no plugin source uploads fine and reports 0%
+          blocks=$(($(wc -l < summary.txt) - 1))
+          if [ "$blocks" -lt 10 ]; then
+            echo "::error::coverage summary holds $blocks blocks, the profile does not map to plugin sources"
+            exit 1
+          fi
 
       - name: Upload to codecov
         uses: codecov/codecov-action@v7 # Docs: <https://github.com/codecov/codecov-action>


### PR DESCRIPTION
Coverage has been reporting 0% while the suite has ~1100 lines of tests, and the profile itself is fine — the last green run uploaded 3149 bytes.

The codecov job has no `actions/checkout`. Without the repo present, codecov cannot map the paths in the profile onto repo files and drops all of them. `download-artifact` also ran without a `path`, so the `*.out` glob depended on the working directory.

Adds the checkout and an explicit `path: coverage`. Adds a guard that fails the job when the merged summary holds fewer than 10 blocks — tokenless uploads fail open, which is why this went unnoticed.
